### PR TITLE
fix: disable stripping for Windows pyinstaller builds

### DIFF
--- a/opencontext.spec
+++ b/opencontext.spec
@@ -1,4 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
+import sys
+
+is_windows = sys.platform.startswith("win")
 
 a = Analysis(
     ['opencontext/cli.py'],
@@ -39,7 +42,7 @@ exe = EXE(
     name='main',
     debug=False,
     bootloader_ignore_signals=False,
-    strip=True,
+    strip=not is_windows,
     upx=False,
     upx_exclude=[],
     runtime_tmpdir=None,


### PR DESCRIPTION
## Description

Disable PyInstaller binary stripping when building on Windows, resolving the Windows packaging failure tracked in issue #99.

closes #99


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/volcengine/MineContext/issues)
for this change. If not, please create an issue before you create this PR, unless the fix is very small.

Not adhering to this guideline will result in the PR being closed.

<!-- ## Tests -->
<!-- There are no hive tests yet -->
