### PR TITLE
docs: Use square brackets consistently in en-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,10 @@ The following is the filling process after obtaining the API Key:
 
 ## 4. Start Recording
 
-Enter 【Screen Monitor】 to enable the system permissions for screen sharing. After completing the setup, you need to restart the application for the changes to take effect.
+Enter [Screen Monitor] to enable the system permissions for screen sharing. After completing the setup, you need to restart the application for the changes to take effect.
 ![Enable-Permissions](src/Enable-Permissions.gif)
 
-After restarting the application, please first set your screen sharing area in 【Settings】, then click [Start Recording] to begin taking screenshots.
+After restarting the application, please first set your screen sharing area in [Settings], then click [Start Recording] to begin taking screenshots.
 ![Screen-Settings](src/Screen-Settings.gif)
 
 ## 5. Forget it


### PR DESCRIPTION
I think en readme should use [], rather than not 【】


[this part link](https://github.com/volcengine/MineContext?tab=readme-ov-file#4-start-recording)
<img width="918" height="754" alt="image" src="https://github.com/user-attachments/assets/bc77ec83-4241-4a88-be51-725fe462049d" />

Rather than [zh-readme](https://github.com/volcengine/MineContext/blob/main/README_zh.md#4-%E5%BC%80%E5%A7%8B%E8%AE%B0%E5%BD%95):
<img width="1063" height="829" alt="image" src="https://github.com/user-attachments/assets/207a7627-0119-44b4-8d14-ca56d036b9cb" />

Or zh and en readme consistently use 【】


## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please
mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/volcengine/MineContext/issues)
for this change. If not, please create an issue before you create this PR, unless the fix is very small.

Not adhering to this guideline will result in the PR being closed.

<!-- ## Tests -->
<!-- There are no hive tests yet -->
