### PR TITLE
docs: Fix formatting and spacing in README_zh.md

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -132,11 +132,11 @@ sudo xattr -d com.apple.quarantine "/Applications/MineContext.app"
 ## 3. 输入您的 API 密钥
 
 应用程序启动后（首次运行时需要安装后端环境，约需等待两分钟），请根据引导输入您的 API 密钥。目前我们支持豆包、OpenAI 以及自定义模型服务，包括任何兼容 OpenAI API 格式的**本地模型**或**第三方模型**服务。
-我们推荐使用[LMStudio](https://lmstudio.ai/)来运行本地模型，它提供了简单的界面和强大的功能，能够帮助您快速部署和管理本地模型。
+我们推荐使用 [LMStudio](https://lmstudio.ai/) 来运行本地模型，它提供了简单的界面和强大的功能，能够帮助您快速部署和管理本地模型。
 
-**综合成本和性能，我们推荐使用豆包模型**，豆包模型的 API-Key 可以在[API 管理界面](https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey)生成。
+**综合成本和性能，我们推荐使用豆包模型**，豆包模型的 API-Key 可以在 [API 管理界面](https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey) 生成。
 
-获取豆包 API 之后需要在[模型开通管理界面](https://console.volcengine.com/ark/region:ark+cn-beijing/model)开通视觉语言模型和向量化两个模型。
+获取豆包 API 之后需要在 [模型开通管理界面](https://console.volcengine.com/ark/region:ark+cn-beijing/model) 开通视觉语言模型和向量化两个模型。
 
 - 视觉语言模型: Doubao-Seed-1.6-flash
   ![doubao-vlm-model](src/doubao-vlm-model.png)


### PR DESCRIPTION
## Description
I think this fix reads well more comfortable 

[before](https://github.com/volcengine/MineContext/blob/main/README_zh.md#3-%E8%BE%93%E5%85%A5%E6%82%A8%E7%9A%84-api-%E5%AF%86%E9%92%A5):
<img width="1096" height="232" alt="image" src="https://github.com/user-attachments/assets/d9a6431b-27a6-4cac-bd78-17506519026f" />

after:
<img width="1005" height="239" alt="image" src="https://github.com/user-attachments/assets/a82d4b86-6a29-41c3-b11a-212963a44c0a" />


other:
<img width="447" height="323" alt="image" src="https://github.com/user-attachments/assets/28e10ea7-a552-40b0-9ca4-d20a3256a16d" />


Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please
mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/volcengine/MineContext/issues)
for this change. If not, please create an issue before you create this PR, unless the fix is very small.

Not adhering to this guideline will result in the PR being closed.

<!-- ## Tests -->
<!-- There are no hive tests yet -->
