### PR TITLE
fix(settings): Restore original config when switching to Custom Platform

### DIFF
--- a/frontend/src/renderer/src/pages/settings/settings.tsx
+++ b/frontend/src/renderer/src/pages/settings/settings.tsx
@@ -120,6 +120,8 @@ const Settings: FC<Props> = (props: Props) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  // originalConfig from backend  
+  const [originalConfig, setOriginalConfig] = useState<any>(null)
 
   const ModelInfoList = ModelInfoMap()
   const [form] = Form.useForm()
@@ -139,12 +141,28 @@ const Settings: FC<Props> = (props: Props) => {
     return foundItem ? foundItem.option : []
   }, [modelPlatform])
 
+  // recover originalConfig when switch to custom
+  useEffect(() => {
+    if (isCustom && originalConfig) {
+      form.setFieldsValue({
+        modelId: originalConfig.modelId,
+        baseUrl: originalConfig.baseUrl,
+        apiKey: originalConfig.apiKey,
+        embeddingModelId: originalConfig.embeddingModelId,
+        embeddingBaseUrl: originalConfig.embeddingBaseUrl,
+        embeddingApiKey: originalConfig.embeddingApiKey
+      })
+    }
+  }, [isCustom, originalConfig])
+
   const getInfo = async () => {
     const res = await getModelInfo()
 
     if (res.data.config.apiKey === '') {
       setInit(false)
     } else {
+      // save originalConfig
+      setOriginalConfig(res.data.config)
       form.setFieldsValue(res.data.config)
       setInit(true)
     }


### PR DESCRIPTION
fix(settings): Restore original config when switching to Custom Platform

Description :
This PR fixes a bug where switching to Custom Platform retains the modelId from the previous platform instead of displaying the custom configuration fetched from the backend.

Changes :

- Added originalConfig state to store the original configuration fetched from the backend
- Modified the useMemo hook to not set modelId when on Custom Platform, preserving the original value
- Added useEffect to monitor platform switches and restore original configuration when switching to Custom Platform
- Updated getInfo function to save the original configuration fetched from the backend
Testing :

- Verified that switching from Doubao to Custom Platform now correctly displays the custom configuration
- Verified that switching from OpenAI to Custom Platform now correctly displays the custom configuration
- Confirmed that switching between Doubao and OpenAI still works as expected
Issue :
Fixes #146 