### PR TITLE
fix: change 'false' to 'False' in processor_manager.py (Python boolean)

### DIFF
--- a/opencontext/managers/processor_manager.py
+++ b/opencontext/managers/processor_manager.py
@@ -169,7 +169,7 @@ class ContextProcessorManager:
             logger.exception(
                 f"Processing component '{processor_name}' encountered exception while processing data: {e}"
             )
-        return false
+        return False
 
     def batch_process(
         self, initial_inputs: List[RawContextProperties]


### PR DESCRIPTION
## Description

This PR fixes a typo: 'false' → 'False' in line 172 of processor_manager.py.
The lowercase 'false' is invalid in Python and should be replaced with the correct boolean literal.
