### PR TITLE
fix: resolve Windows OpenSSL Applink error in PyInstaller build

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -9,11 +9,18 @@ echo.
 
 REM 1. Dependency Check
 echo --^> Checking for python...
-python --version >nul 2>&1
-if errorlevel 1 (
-    echo Error: python is not found. Please install Python 3.
-    exit /b 1
+where py >nul 2>&1
+if %errorlevel% equ 0 (
+    set PYTHON_CMD=py
+) else (
+    where python >nul 2>&1
+    if errorlevel 1 (
+        echo Error: python is not found. Please install Python 3.
+        exit /b 1
+    )
+    set PYTHON_CMD=python
 )
+%PYTHON_CMD% --version
 
 set USE_UV=false
 
@@ -29,7 +36,7 @@ if %errorlevel% equ 0 (
     set USE_UV=true
 ) else (
     echo --^> uv not found, using pip to install from pyproject.toml...
-    python -m pip install -e .
+    %PYTHON_CMD% -m pip install -e .
     if errorlevel 1 (
         echo Error: pip install failed.
         exit /b 1
@@ -49,10 +56,10 @@ if "!USE_UV!"=="true" (
         )
     )
 ) else (
-    python -c "import PyInstaller" >nul 2>&1
+    %PYTHON_CMD% -c "import PyInstaller" >nul 2>&1
     if errorlevel 1 (
         echo --^> PyInstaller not found. Installing...
-        python -m pip install pyinstaller
+        %PYTHON_CMD% -m pip install pyinstaller
         if errorlevel 1 (
             echo Error: Failed to install PyInstaller with pip.
             exit /b 1

--- a/opencontext.spec
+++ b/opencontext.spec
@@ -13,7 +13,7 @@ a = Analysis(
         ('opencontext/web/templates', 'opencontext/web/templates')
     ],
     hiddenimports=[
-        'uvicorn.protocols.http.auto', 
+        'uvicorn.protocols.http.auto',
         'uvicorn.protocols.websockets.auto',
         'chromadb.telemetry.product.posthog',
         'chromadb.api.rust',
@@ -23,6 +23,8 @@ a = Analysis(
         'chromadb.segment.impl.metadata.sqlite',
         'hnswlib',
         'sqlite3',
+        '_ssl',
+        '_hashlib',
     ],
     hookspath=['.'],
     hooksconfig={},


### PR DESCRIPTION
## Problem
  On Windows platform, the backend service (`main.exe`) crashes 2 seconds after startup with the following error:
  OPENSSL_Uplink(00007FFEC90E7C58,08): no OPENSSL_Applink
  Backend process exited with code 1
  This prevents the application from working on Windows.

## Root Cause
  PyInstaller on Windows requires explicit inclusion of SSL-related hidden imports (`_ssl` and `_hashlib`) to
  properly link with OpenSSL DLLs. Without these imports, the compiled executable encounters OpenSSL Applink errors.

  ## Solution
  1. **opencontext.spec**: Added `'_ssl'` and `'_hashlib'` to the `hiddenimports` list
  2. **build.bat**: Improved Python command detection to support both `python` and `py` commands for better Windows
  compatibility

  ## Testing
  - ✅ Built on Windows 10/11 with Python 3.12.3
  - ✅ Backend service starts successfully and runs continuously
  - ✅ No OpenSSL errors in logs
  - ✅ All components initialize properly
  - ✅ Application works end-to-end

  ## Files Changed
  - `opencontext.spec`: Added SSL-related hidden imports
  - `build.bat`: Enhanced Python command detection

  Closes #192
