### PR TITLE
feat: upgrade OpenAI models from GPT-4.1 to GPT-5 series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__
 uv.lock
 uv.toml
 .idea
+.claude/

--- a/frontend/src/renderer/src/pages/settings/constants.tsx
+++ b/frontend/src/renderer/src/pages/settings/constants.tsx
@@ -57,16 +57,16 @@ export const ModelInfoList = [
     value: 'openai',
     option: [
       {
-        value: 'gpt-4.1',
-        label: 'GPT-4.1'
+        value: 'gpt-5',
+        label: 'GPT-5'
       },
       {
-        value: 'gpt-4.1-mini',
-        label: 'GPT-4.1 Mini'
+        value: 'gpt-5-mini',
+        label: 'GPT-5 Mini'
       },
       {
-        value: 'gpt-4.1-nano',
-        label: 'GPT-4.1 Nano'
+        value: 'gpt-5-nano',
+        label: 'GPT-5 Nano'
       }
     ]
   },

--- a/frontend/src/renderer/src/pages/settings/settings.tsx
+++ b/frontend/src/renderer/src/pages/settings/settings.tsx
@@ -291,7 +291,7 @@ const Settings: FC<SettingsProps> = (props) => {
               initialValues={{
                 modelPlatform: ModelTypeList.Doubao,
                 [`${ModelTypeList.Doubao}-modelId`]: 'doubao-seed-1-6-flash-250828',
-                [`${ModelTypeList.OpenAI}-modelId`]: 'gpt-4.1-nano'
+                [`${ModelTypeList.OpenAI}-modelId`]: 'gpt-5-nano'
               }}>
               <FormItem label="Model platform" field={'modelPlatform'} requiredSymbol={false}>
                 <ModelRadio />

--- a/opencontext/web/templates/settings.html
+++ b/opencontext/web/templates/settings.html
@@ -52,7 +52,7 @@
                         </div>
                         <div class="mb-3">
                             <label for="modelId" class="form-label">模型 ID</label>
-                            <input type="text" class="form-control" id="modelId" placeholder="例如: gpt-4" required>
+                            <input type="text" class="form-control" id="modelId" placeholder="例如: gpt-5" required>
                         </div>
                         <div class="mb-3">
                             <label for="baseUrl" class="form-label">Base URL</label>


### PR DESCRIPTION
##  改進內容
升級 OpenAI 模型選項從 GPT-4.1 系列到 GPT-5 系列，提供更好的性價比（成本約一半以下，同時提升多模態性能）。同時添加了`.claude/`進入`gitignore`以排除本地開發檔案。

### 變更詳情
- **模型選項更新**: GPT-4.1 → GPT-5, GPT-4.1 Mini → GPT-5 Mini, GPT-4.1 Nano → GPT-5 Nano
- **預設模型**: 將 `gpt-5-nano` 設為新的預設 OpenAI 模型
- **UI 更新**: 更新設定頁面和 web 模板的模型選項顯示
- **開發環境**: 添加 `.claude/` 到 `.gitignore` 以排除本地開發檔案

### 影響範圍
-  前端模型選擇 UI
-  預設配置值
-  Web 模板佔位符
-  .gitignore 檔案

### 測試狀態
-  本地前端 UI 測試已通過並可正常運行
-  模型選項正常顯示
-  預設值配置正確

### 檔案變更
- `frontend/src/renderer/src/pages/settings/constants.tsx`
- `frontend/src/renderer/src/pages/settings/settings.tsx`  
- `opencontext/web/templates/settings.html`
- `.gitignore`