### PR TITLE
fix: Adopt Electron's single instance lock

### DIFF
--- a/frontend/src/main/index.ts
+++ b/frontend/src/main/index.ts
@@ -38,6 +38,21 @@ autoUpdater.logger = logger
 const isPackaged = app.isPackaged
 const actuallyDev = isDev && !isPackaged // true
 
+const gotLock = app.requestSingleInstanceLock()
+if (!gotLock) {
+  app.quit()
+  process.exit(0)
+} else {
+  app.on('second-instance', () => {
+    const win = BrowserWindow.getAllWindows()[0]
+    if (win) {
+      if (win.isMinimized()) win.restore()
+      win.show()
+      win.focus()
+    }
+  })
+}
+
 // Save the original console.log
 const originalConsoleLog = console.log
 


### PR DESCRIPTION
fix: Adopt Electron's single instance lock to fix the issues of multiple background instances and timeline overlap.(#270)

## Description

Implement Electron’s single-instance control in the main process so subsequent launches do not create new app instances or backend processes.
Files changed:`frontend/src/main/index.ts:41–54` adds single-instance lock and second-instance handler
Closes: #270


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/volcengine/MineContext/issues)
for this change. If not, please create an issue before you create this PR, unless the fix is very small.

Not adhering to this guideline will result in the PR being closed.

<!-- ## Tests -->
After the first instance is running, launching npm run dev again causes the second process to exit immediately and brings the existing instance to the foreground (restored and focused).
<img width="1167" height="945" alt="image" src="https://github.com/user-attachments/assets/140834ec-7863-4413-8281-6782df92cb7d" />

<!-- There are no hive tests yet -->
