### PR TITLE
feat: Optimize initial API key validation UX (timeout & error messages) / 优化初始化 API Key 验证体验（超时控制与错误提示）

### DIFF
--- a/opencontext/server/routes/settings.py
+++ b/opencontext/server/routes/settings.py
@@ -62,6 +62,11 @@ def _build_llm_config(
 ) -> dict:
     """Build LLM config dict"""
     config = {"base_url": base_url, "api_key": api_key, "model": model, "provider": provider}
+    
+    # Add optional parameters
+    if "timeout" in kwargs:
+        config["timeout"] = kwargs["timeout"]
+
     if llm_type == LLMType.EMBEDDING:
         config["output_dim"] = kwargs.get("output_dim", 2048)
     return config
@@ -130,7 +135,7 @@ async def update_model_settings(request: UpdateModelSettingsRequest, _auth: str 
 
             # Validate VLM
             vlm_config = _build_llm_config(
-                cfg.baseUrl, vlm_key, cfg.modelId, cfg.modelPlatform, LLMType.CHAT
+                cfg.baseUrl, vlm_key, cfg.modelId, cfg.modelPlatform, LLMType.CHAT, timeout=15
             )
             vlm_valid, vlm_msg = LLMClient(llm_type=LLMType.CHAT, config=vlm_config).validate()
             if not vlm_valid:
@@ -140,7 +145,7 @@ async def update_model_settings(request: UpdateModelSettingsRequest, _auth: str 
 
             # Validate Embedding
             emb_config = _build_llm_config(
-                emb_url, emb_key, cfg.embeddingModelId, emb_provider, LLMType.EMBEDDING
+                emb_url, emb_key, cfg.embeddingModelId, emb_provider, LLMType.EMBEDDING, timeout=15
             )
             emb_valid, emb_msg = LLMClient(llm_type=LLMType.EMBEDDING, config=emb_config).validate()
             if not emb_valid:
@@ -210,10 +215,10 @@ async def validate_llm_config(request: UpdateModelSettingsRequest, _auth: str = 
 
         # Build configs for validation (without saving)
         vlm_config = _build_llm_config(
-            cfg.baseUrl, vlm_key, cfg.modelId, cfg.modelPlatform, LLMType.CHAT
+            cfg.baseUrl, vlm_key, cfg.modelId, cfg.modelPlatform, LLMType.CHAT, timeout=15
         )
         emb_config = _build_llm_config(
-            emb_url, emb_key, cfg.embeddingModelId, emb_provider, LLMType.EMBEDDING
+            emb_url, emb_key, cfg.embeddingModelId, emb_provider, LLMType.EMBEDDING, timeout=15
         )
 
         # Validate VLM


### PR DESCRIPTION
#### 🇬🇧 English

**Problem**:
1.  **UI Hanging**: During the initial setup, if the user enters an API key for a service that isn't enabled (e.g., Volcengine model not activated) or if the network is unstable, the validation request could hang indefinitely. The "spinning" loader would never stop, providing no feedback to the user.
2.  **Obscure Errors**: Raw API error responses (like 400 Bad Request with complex JSON) were displayed directly to users, making it hard to diagnose issues like "Insufficient Quota" or "Access Denied".

**Solution**:
1.  **Timeout Control**: Implemented a forced **15-second timeout** for the model validation step in the backend (`settings.py`). This ensures the UI always recovers and reports a failure if the API is unresponsive.
2.  **Friendly Error Messages**: Enhanced the `LLMClient.validate` method to parse specific error codes from Volcengine and OpenAI.
    *   Mapped `AccessDenied` -> "Access denied. Please ensure the model is enabled in the Volcengine console."
    *   Mapped `QuotaExceeded` / `insufficient_quota` -> Friendly reminders to check account balance.
    *   General improvements to error summary extraction.

**Changes**:
*   `opencontext/server/routes/settings.py`: Added timeout parameter to LLM config and applied it during update/validate endpoints.
*   `opencontext/llm/llm_client.py`: Added error code mapping logic to `_extract_error_summary`.

---

#### 🇨🇳 中文

**问题**:
1.  **界面卡死**: 在首次设置 API Key 时，如果用户填写的 Key 对应的服务未开通（例如火山引擎未开通对应的豆包模型接入点），或者网络不通，验证请求可能会一直挂起。前端界面的“转圈”加载状态不会停止，用户得不到任何反馈。
2.  **报错难懂**: 之前直接展示原始的 API 错误信息（通常是复杂的 JSON 或晦涩的错误码），用户很难直观判断是“余额不足”还是“未开通服务”。

**解决方案**:
1.  **超时控制**: 在后端 (`settings.py`) 的模型验证步骤中增加了强制的 **15 秒超时**限制。确保即使 API 无响应，也能及时失败并反馈给前端，避免界面假死。
2.  **友好报错**: 增强了 `LLMClient.validate` 方法，支持解析火山引擎和 OpenAI 的特定错误码。
    *   映射 `AccessDenied` -> 提示用户去控制台开通模型服务。
    *   映射 `QuotaExceeded` / `insufficient_quota` -> 提示用户检查账户余额。
    *   优化了通用的错误摘要提取逻辑。

**修改文件**:
*   `opencontext/server/routes/settings.py`: 为 LLM 配置增加了 timeout 参数，并在更新/验证接口中应用。
*   `opencontext/llm/llm_client.py`: 在 `_extract_error_summary` 中增加了错误码映射逻辑。