### PR TITLE
fix: correct screen monitor interval behavious

### DIFF
--- a/frontend/src/main/background/task/screen-monitor-task.ts
+++ b/frontend/src/main/background/task/screen-monitor-task.ts
@@ -58,7 +58,7 @@ class ScreenMonitorTask extends ScheduleNextTask {
     })
     ipcMain.handle(IpcChannel.Task_Update_Model_Config, (_, config: ScreenSettings) => {
       this.modelConfig = config
-      this.updateInterval(config.recordInterval)
+      this.updateInterval(config.recordInterval * 1000)
     })
     ipcMain.handle(IpcChannel.Task_Start, () => {
       logger.info('render notify ScreenMonitorTask start')


### PR DESCRIPTION
## Description

**Symptom**: set the screenshot interval as 60s in the GUI, but the system generates about 17 directories per minute (approximately one every 3.5 seconds).
**Code logic**:
The recordInterval stored in the frontend ScreenSettings is in seconds (e.g., 60).
The backend task scheduler ScheduleNextTask expects the unit to be milliseconds.
In ScreenMonitorTask.ts, the value 60 is directly passed to the scheduler: this.updateInterval(config.recordInterval).
Result: The scheduler attempts to execute screenshots every 60 milliseconds.
Actual frequency: Since the screenshot operation itself (capturing the source, converting the image, writing to disk) takes about 3-4 seconds, it effectively becomes "screenshot as fast as possible," resulting in approximately 16-17 times per minute (60 seconds / 3.5 seconds ≈ 17).

Closes: #(issue)
https://github.com/volcengine/MineContext/issues/316

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/volcengine/MineContext/issues)
for this change. If not, please create an issue before you create this PR, unless the fix is very small.

Not adhering to this guideline will result in the PR being closed.

<!-- ## Tests -->
<!-- There are no hive tests yet -->
