### PR TITLE
fix: replace 9 bare excepts with except Exception across 5 files

### DIFF
--- a/opencontext/context_consumption/generation/smart_todo_manager.py
+++ b/opencontext/context_consumption/generation/smart_todo_manager.py
@@ -92,7 +92,7 @@ class SmartTodoManager:
                             deadline = datetime.datetime.strptime(deadline_str, "%Y-%m-%d %H:%M")
                         else:
                             deadline = datetime.datetime.strptime(task["due_date"], "%Y-%m-%d")
-                    except:
+                    except Exception:
                         pass
 
                 todo_id = get_storage().insert_todo(

--- a/opencontext/llm/llm_client.py
+++ b/opencontext/llm/llm_client.py
@@ -439,7 +439,7 @@ class LLMClient:
                                         if ". Request id:" in actual_msg:
                                             actual_msg = actual_msg.split(". Request id:")[0]
                                         return actual_msg
-                            except:
+                            except Exception:
                                 pass
                         return f"Error {code}"
 

--- a/opencontext/monitoring/metrics_collector.py
+++ b/opencontext/monitoring/metrics_collector.py
@@ -48,7 +48,7 @@ class MetricsCollector:
                     if hasattr(result, "__len__") and not isinstance(result, str):
                         try:
                             context_count = len(result)
-                        except:
+                        except Exception:
                             context_count = 1
 
                     monitor.record_processing_metrics(
@@ -94,7 +94,7 @@ class MetricsCollector:
                     elif hasattr(result, "__len__") and not isinstance(result, str):
                         try:
                             snippets_count = len(result)
-                        except:
+                        except Exception:
                             snippets_count = 0
 
                     # 尝试从参数中获取query

--- a/opencontext/storage/backends/sqlite_backend.py
+++ b/opencontext/storage/backends/sqlite_backend.py
@@ -951,7 +951,7 @@ class SQLiteBackend(IDocumentStorageBackend):
             logger.error(f"Failed to save token usage: {e}")
             try:
                 self.connection.rollback()
-            except:
+            except Exception:
                 pass
             return False
 
@@ -1047,7 +1047,7 @@ class SQLiteBackend(IDocumentStorageBackend):
             logger.error(f"Failed to save stage timing: {e}")
             try:
                 self.connection.rollback()
-            except:
+            except Exception:
                 pass
             return False
 
@@ -1087,7 +1087,7 @@ class SQLiteBackend(IDocumentStorageBackend):
             logger.error(f"Failed to save data stats: {e}")
             try:
                 self.connection.rollback()
-            except:
+            except Exception:
                 pass
             return False
 
@@ -1313,7 +1313,7 @@ class SQLiteBackend(IDocumentStorageBackend):
             logger.error(f"Failed to cleanup old monitoring data: {e}")
             try:
                 self.connection.rollback()
-            except:
+            except Exception:
                 pass
             return False
 

--- a/opencontext/utils/json_parser.py
+++ b/opencontext/utils/json_parser.py
@@ -101,5 +101,5 @@ def _fix_json_quotes(json_str: str) -> str:
     try:
         fixed = re.sub(pattern, fix_quotes_in_match, json_str)
         return fixed
-    except:
+    except Exception:
         return json_str


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in 5 files (9 sites).

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt`/`SystemExit`.

**Files:** `smart_todo_manager.py`, `llm_client.py`, `metrics_collector.py` (2), `sqlite_backend.py` (4), `json_parser.py`