### PR TITLE
fix(security): validate file paths in /api/documents/upload

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -209,6 +209,23 @@ api_auth:
     - "/assistant"
     - "/vaults"
 
+# Security-related settings
+security:
+  # Allow-list for the /api/documents/upload endpoint. Any file path passed
+  # to this endpoint must resolve to a location under one of these roots,
+  # otherwise the upload is rejected. This prevents the endpoint from being
+  # abused to read arbitrary files (e.g. ~/.ssh/id_rsa) and ship their
+  # contents to the configured VLM/embedding provider.
+  #
+  # Paths under capture.folder_monitor.watch_folder_paths are implicitly
+  # allowed and do not need to be repeated here.
+  #
+  # If both this list and watch_folder_paths are empty, the upload endpoint
+  # falls back to ~/Documents, ~/Downloads and ~/Desktop (when they exist).
+  document_upload_allowed_paths: []
+    # - "${CONTEXT_PATH:.}/uploads"
+    # - "~/Documents/MineContext"
+
 # Prompts configuration
 prompts:
   language: "zh"

--- a/opencontext/server/context_operations.py
+++ b/opencontext/server/context_operations.py
@@ -11,7 +11,8 @@ Separated from main OpenContext class for better maintainability.
 
 import datetime
 import os
-from typing import Any, Dict, List, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 from opencontext.models.context import ProcessedContext, RawContextProperties, Vectorize
 from opencontext.models.enums import (
@@ -24,6 +25,135 @@ from opencontext.storage.global_storage import get_storage
 from opencontext.utils.logging_utils import get_logger
 
 logger = get_logger(__name__)
+
+
+# Path components / locations that must never be ingested by /api/documents/upload,
+# regardless of the configured allow-list. These hold credentials, keys, or system
+# state whose contents would be sent to the configured (potentially remote)
+# VLM/embedding provider for processing.
+_SENSITIVE_PATH_COMPONENTS = frozenset(
+    {
+        ".ssh",
+        ".aws",
+        ".gnupg",
+        ".azure",
+        ".gcloud",
+        ".kube",
+        ".docker",
+        ".password-store",
+        "Keychains",
+    }
+)
+
+_SENSITIVE_FILENAMES = frozenset(
+    {
+        ".env",
+        "id_rsa",
+        "id_ed25519",
+        "id_ecdsa",
+        "id_dsa",
+        "shadow",
+    }
+)
+
+_SENSITIVE_PATH_PREFIXES = (
+    "/etc",
+    "/proc",
+    "/sys",
+    "/dev",
+    "/root",
+    "/var/log",
+    "/var/db",
+    "/private/etc",
+    "/private/var/log",
+    "/private/var/db",
+)
+
+
+def _is_sensitive_path(path: Path) -> Tuple[bool, str]:
+    """Defense-in-depth deny check for clearly sensitive locations."""
+    for part in path.parts:
+        if part in _SENSITIVE_PATH_COMPONENTS:
+            return True, f"path contains sensitive directory '{part}'"
+    if path.name in _SENSITIVE_FILENAMES:
+        return True, f"file '{path.name}' is on sensitive-filename deny list"
+    path_str = str(path)
+    for prefix in _SENSITIVE_PATH_PREFIXES:
+        if path_str == prefix or path_str.startswith(prefix + os.sep):
+            return True, f"path is under sensitive system directory '{prefix}'"
+    return False, ""
+
+
+def _resolve_paths_from_config(values: Any) -> List[Path]:
+    """Coerce a config value (string, list of strings, or None) into a list of
+    resolved absolute Paths. Silently skips entries that fail to resolve."""
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, list):
+        return []
+    out: List[Path] = []
+    for raw in values:
+        if not isinstance(raw, str) or not raw:
+            continue
+        try:
+            out.append(Path(raw).expanduser().resolve())
+        except Exception:
+            continue
+    return out
+
+
+def _resolve_allowed_upload_roots(config: Optional[Dict[str, Any]]) -> List[Path]:
+    """Compute the set of directories under which a path passed to
+    /api/documents/upload is permitted to live.
+
+    Sources, in order:
+      1. capture.folder_monitor.watch_folder_paths — directories the user has
+         already opted in to having watched/processed.
+      2. security.document_upload_allowed_paths — explicit allow-list extension
+         point for the upload endpoint.
+      3. Fallback if neither is set: ~/Documents, ~/Downloads, ~/Desktop.
+    """
+    cfg = config or {}
+    roots: List[Path] = []
+
+    capture_cfg = cfg.get("capture") or {}
+    folder_monitor_cfg = capture_cfg.get("folder_monitor") or {}
+    roots.extend(_resolve_paths_from_config(folder_monitor_cfg.get("watch_folder_paths")))
+
+    security_cfg = cfg.get("security") or {}
+    roots.extend(_resolve_paths_from_config(security_cfg.get("document_upload_allowed_paths")))
+
+    if not roots:
+        try:
+            home = Path.home().resolve()
+            for sub in ("Documents", "Downloads", "Desktop"):
+                candidate = home / sub
+                if candidate.exists():
+                    roots.append(candidate)
+        except Exception:
+            pass
+
+    # De-duplicate while preserving order.
+    seen = set()
+    unique: List[Path] = []
+    for r in roots:
+        key = str(r)
+        if key not in seen:
+            seen.add(key)
+            unique.append(r)
+    return unique
+
+
+def _is_path_under_any_root(path: Path, roots: List[Path]) -> bool:
+    for root in roots:
+        try:
+            path.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
 
 
 class ContextOperations:
@@ -115,18 +245,53 @@ class ContextOperations:
     def add_document(self, file_path: str, context_processor_callback) -> Optional[str]:
         """Add a document to the system."""
         import uuid
-        from pathlib import Path
+
+        from opencontext.config.global_config import get_config
 
         # Validate inputs
         if not file_path:
             return "Document path cannot be empty"
 
-        path = Path(file_path).expanduser()
+        expanded = Path(file_path).expanduser()
+        if not expanded.is_absolute():
+            return "Document path must be absolute"
+
+        try:
+            path = expanded.resolve(strict=False)
+        except Exception as e:
+            return f"Cannot resolve document path: {e}"
+
         if not path.exists():
             return f"Document path {file_path} does not exist"
 
         if not path.is_file():
             return f"Path {file_path} is not a file"
+
+        # The contents of any file accepted here are forwarded to the configured
+        # VLM / embedding provider for processing, so this endpoint must not be
+        # usable as an arbitrary file-read primitive against the host.
+        sensitive, reason = _is_sensitive_path(path)
+        if sensitive:
+            logger.warning(
+                "Rejected document upload from sensitive path: %s (%s)", file_path, reason
+            )
+            return f"Document path is not allowed: {reason}"
+
+        allowed_roots = _resolve_allowed_upload_roots(get_config())
+        if not _is_path_under_any_root(path, allowed_roots):
+            roots_pretty = ", ".join(str(r) for r in allowed_roots) if allowed_roots else "<none>"
+            logger.warning(
+                "Rejected document upload from path outside allow-list: %s "
+                "(allowed roots: [%s])",
+                file_path,
+                roots_pretty,
+            )
+            return (
+                f"Document path is not within an allowed directory. "
+                f"Allowed roots: [{roots_pretty}]. "
+                f"To permit additional directories, set "
+                f"'security.document_upload_allowed_paths' in config.yaml."
+            )
 
         try:
             # Create RawContextProperties


### PR DESCRIPTION
## Summary

`/api/documents/upload` currently accepts any absolute path on the host and feeds the file's contents into the document-processing pipeline, which forwards them to the configured VLM / embedding provider (often a remote API). With `api_auth.enabled` defaulting to `false`, any process that can reach `127.0.0.1:1733` can exfiltrate arbitrary user files this way — defeating the project's stated privacy posture (\"Your data is processed and stored entirely on your local device\").

This PR adds a path allow-list plus a defense-in-depth deny list to that endpoint. The set of permitted directories is sourced from the user's existing watched folders and a new explicit config knob, with sensible fallback defaults.

## Threat model

The endpoint is reachable not only from the official UI but also from any co-located process able to talk to localhost:

- Browser extensions with `host_permissions` for `http://127.0.0.1:1733/*` (background pages bypass CORS).
- Malicious dev-time dependencies (`npm`, `pip`, VS Code extensions) running under the user.
- Sibling containers sharing the host network namespace.
- Any user that has changed `web.host` to bind beyond loopback.

Because these clients are not browsers issuing a cross-origin `fetch`, the existing CORS allow-list does not apply.

### Reproducer (against `main` before this patch)

```bash
# Default config has api_auth.enabled=false, so no auth header needed.
curl -s -X POST http://127.0.0.1:1733/api/documents/upload \
  -H 'Content-Type: application/json' \
  -d '{"file_path":"/Users/<you>/.ssh/id_rsa"}'
# -> {"code":0,"message":"Document queued for processing successfully"}
```

The file is then read by `ContextOperations.add_document` and passed through `generate_with_messages_async` (`opencontext/llm/global_vlm_client.py`) to the configured `vlm_model.base_url` for OCR / summarization, and through `do_vectorize_async` for embedding. An attacker who additionally calls `/api/model_settings/update` (also unauthenticated by default) can swap that base URL to a server they control before triggering the upload, completing the exfiltration in two requests.

## Fix

`opencontext/server/context_operations.py` — `add_document()` now:

1. Requires an absolute path and `resolve()`s it (symlinks followed) before any check, so `..` and symlink games cannot escape the allow-list.
2. Hard-denies paths whose components match a small list of clearly sensitive names (`.ssh`, `.aws`, `.gnupg`, `.azure`, `.gcloud`, `.kube`, `.docker`, `.password-store`, `Keychains`), whose filename matches `.env`, `id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`, `shadow`, or whose prefix is under `/etc`, `/proc`, `/sys`, `/dev`, `/root`, `/var/log`, `/var/db` (and the `/private/...` equivalents on macOS) — independent of the allow-list.
3. Otherwise requires the resolved path to live under one of:
   - `capture.folder_monitor.watch_folder_paths` (directories the user has already opted in to having watched).
   - `security.document_upload_allowed_paths` (new config, explicit extension point — see updated `config/config.yaml`).
   - Fallback when neither is configured: `~/Documents`, `~/Downloads`, `~/Desktop` (only those that exist).
4. Returns a descriptive error message on rejection, including the active allow-list and the config key the user can edit to extend it.

Helpers (`_is_sensitive_path`, `_resolve_paths_from_config`, `_resolve_allowed_upload_roots`, `_is_path_under_any_root`) are private module-level functions to keep `add_document` itself readable and to make the predicates easy to reason about in isolation.

## Behavior on the legitimate path

- Users who have configured `watch_folder_paths` (the documented \"watch this folder\" workflow) keep working with no config changes.
- Users on a fresh install whose chosen documents live in `~/Documents`, `~/Downloads`, or `~/Desktop` keep working with no config changes.
- Users who put documents elsewhere see a clear error pointing at `security.document_upload_allowed_paths`, which they can extend in `config.yaml`.

## Out of scope (worth follow-ups)

This PR fixes the most concrete arbitrary-file-read primitive but does not address the broader pattern of \"privileged endpoints rely on `api_auth` which is off by default.\" In particular `/api/model_settings/update` allowing the LLM `base_url` to be reset over plain HTTP is a separate concern that I'd be happy to follow up on if maintainers agree on the direction.

## Test plan

- [x] `python -m black --check opencontext/server/context_operations.py`
- [x] `python -m isort --check-only opencontext/server/context_operations.py`
- [x] Direct exercise of helpers — verified DENY for `~/.ssh/id_rsa`, `~/.aws/credentials`, `/etc/passwd`, `/proc/1/environ`, `~/.env`, `~/Documents/id_rsa`; ALLOW for `~/Documents/report.pdf`, `~/Downloads/notes.md`. Verified `_resolve_allowed_upload_roots` honors `watch_folder_paths`, `security.document_upload_allowed_paths`, and the `~/Documents` / `~/Downloads` / `~/Desktop` fallback. Verified `_is_path_under_any_root` rejects paths outside the configured roots.
- [ ] Maintainer to reproduce the curl PoC against `main`, then re-run against this branch to confirm the second request returns `Document path is not allowed: ...`.