### PR TITLE
chore: migrate deprecated Doubao model

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ embedding_model:
 vlm_model:
   provider: doubao # options: openai, doubao
   api_key: your-api-key
-  model: doubao-seed-1-6-flash-250828
+  model: doubao-seed-2-0-mini-260428
 
 capture:
   enabled: true

--- a/README_zh.md
+++ b/README_zh.md
@@ -365,7 +365,7 @@ embedding_model:
 vlm_model:
   provider: doubao # 选项：openai, doubao
   api_key: your-api-key
-  model: doubao-seed-1-6-flash-250828
+  model: doubao-seed-2-0-mini-260428
 
 capture:
   enabled: true

--- a/frontend/src/renderer/src/pages/settings/constants.tsx
+++ b/frontend/src/renderer/src/pages/settings/constants.tsx
@@ -38,8 +38,8 @@ export const ModelInfoList = [
     value: 'doubao',
     option: [
       {
-        value: 'doubao-seed-1-6-flash-250828',
-        label: 'doubao-seed-1.6-flash'
+        value: 'doubao-seed-2-0-mini-260428',
+        label: 'doubao-seed-2.0-mini'
       },
       {
         value: 'doubao-1-5-vision-pro-250328',

--- a/frontend/src/renderer/src/pages/settings/settings.tsx
+++ b/frontend/src/renderer/src/pages/settings/settings.tsx
@@ -298,7 +298,7 @@ const Settings: FC<SettingsProps> = (props) => {
               form={form}
               initialValues={{
                 modelPlatform: ModelTypeList.Doubao,
-                [`${ModelTypeList.Doubao}-modelId`]: 'doubao-seed-1-6-flash-250828',
+                [`${ModelTypeList.Doubao}-modelId`]: 'doubao-seed-2-0-mini-260428',
                 [`${ModelTypeList.OpenAI}-modelId`]: 'gpt-5-nano'
               }}>
               <FormItem label="Model platform" field={'modelPlatform'} requiredSymbol={false}>


### PR DESCRIPTION
## Changes
- Replace the deprecated Doubao Seed 1.6 Flash option with Doubao Seed 2.0 Mini.
- Update the default Doubao model used by the settings form.
- Update the English and Chinese configuration examples.

## Verification
- `pnpm typecheck`
